### PR TITLE
Add Lahlang: Singlish-inspired esolang

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Curated list of awesome esoteric programming languages, resources and related pr
 * [Jelly](https://github.com/DennisMitchell/jellylanguage) - Golfing language based on J.
 * [JellyScript](https://github.com/nguyenphuminh/Jellyscript) - Brainfuck-based with delicious jelly.
 * [JSFuck](https://github.com/aemkei/jsfuck) - Esoteric programming style based on the atomic parts of JavaScript.
+* [lahlang](https://lahlang.dev) - Fun, expressive language inspired by Singlish and Singaporean culture.
 * [Lazy K](https://tromp.github.io/cl/lazy-k.html) - Minimal, turing-complete pure functional language without extra features.
 * [legit](https://morr.cc/legit) - Programs defined entirely by the graph of the git repository instead of its contents.
 * [LolCode](http://lolcode.org) - Language with keywords based on the lolcat meme expressions.


### PR DESCRIPTION
This pull request adds Lahlang to the Languages section of the awesome-esolangs list. Lahlang is a fun, expressive programming language inspired by Singlish and Singaporean culture, designed for learning and experimentation. Lahlang is widely considered esoteric and meets the contribution guidelines.

Github Link -> https://github.com/suryanshkushwaha/lahlang
Lahlang Website -> https://lahlang.dev