### PR TITLE
Add LolRust to Languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Curated list of awesome esoteric programming languages, resources and related pr
 * [Lazy K](https://tromp.github.io/cl/lazy-k.html) - Minimal, turing-complete pure functional language without extra features.
 * [legit](https://morr.cc/legit) - Programs defined entirely by the graph of the git repository instead of its contents.
 * [LolCode](http://lolcode.org) - Language with keywords based on the lolcat meme expressions.
+* [LolRust](https://github.com/AdaInTheLab/lolrust) - Lolcat-flavored Rust that transpiles .meow files to valid Rust, keeping the type system and borrow checker.
 * [Malbolge](https://esolangs.org/wiki/Malbolge) - Named after the 8th level of hell, is designed to be as difficult as possible to program.
 * [Mindfck](https://github.com/angrykoala/mindfck) - High level language that transpiles to Brainfuck.
 * [Monicelli](https://github.com/esseks/monicelli) - Programming using Italian-like gibberish.


### PR DESCRIPTION
Adds [LolRust](https://github.com/AdaInTheLab/lolrust) to the Languages section, alphabetically between LolCode and Malbolge.

## Why it's awesome

LolRust is a lolcat-flavored esolang that transpiles `.meow` files into valid Rust. Unlike LolCode (interpreted, mostly a joke), LolRust compiles through `rustc` — so you keep Rust's type system, borrow checker (renamed "the No Touchie Checker"), and zero-cost abstractions.

Example:

```rust
iz main() {
    chase n around 1..=100 {
        if ceiling cat sez n % 15 == 0 {
            meow!("FizzBuzz");
        }
    }
}
```

## Compliance

- Alphabetical placement ✓ (LolCode → LolRust → Malbolge)
- Direct GitHub link ✓
- Description ends with period ✓
- Partially documented (README, wiki, keyword reference, 41-test suite) ✓
- Original author's link ✓ (I'm the author)
- Published to crates.io ✓
- MIT licensed ✓